### PR TITLE
Add Chinese quick-reference documentation and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ An extensible android gallery that supports samba/windows share, http/https/webd
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
  ```
+## 文档
+
+- 新人速查图（中文）：[`docs/quick-reference.zh-CN.md`](docs/quick-reference.zh-CN.md)
+

--- a/docs/quick-reference.zh-CN.md
+++ b/docs/quick-reference.zh-CN.md
@@ -14,7 +14,7 @@ flowchart TB
     subgraph app核心分层
       UI[Activity / Fragment / Adapter\nMainActivity / ViewerActivity / ImageFragment]
       MVP[Contract + Presenter\nMainContact / ViewerContact\nMainPresenter / ViewerPresenter]
-      DATA[Data\nMediaDataSource(MediaRepository)\nMediaCache]
+      DATA[Data\nMediaDataSource / MediaRepository\nMediaCache]
       MODEL[Model\nMedia 抽象 + Local/Samba/WebDav/AutoIndex]
       DB[Database\nRequery + Server 实体]
       DI[Dagger DI\nAppComponent + AppModule]
@@ -82,7 +82,7 @@ flowchart LR
     I[实现 Media 接口\n例如 XxxMedia]
     S[声明 scheme()\n如 xxx://]
     U[实现 fromUri()/children()/getInputStream()/auth()]
-    R[在 MainPresenter.start() 中 register(new XxxMedia())]
+    R[在 MainPresenter.start 中调用 register 新实现]
     D[可选: 在数据库中保存连接信息]
 
     I --> S --> U --> R --> D

--- a/docs/quick-reference.zh-CN.md
+++ b/docs/quick-reference.zh-CN.md
@@ -1,0 +1,111 @@
+# Gallery 代码库速查图（新人向）
+
+> 一张图 + 最短路径，快速理解：从主界面到数据层，再到多协议媒体实现。
+
+## 1) 整体架构速查（模块 & 分层）
+
+```mermaid
+flowchart TB
+    subgraph Gradle工程
+      A[app 模块\nAndroid 应用]
+      B[photoview 模块\n图片缩放/手势库]
+    end
+
+    subgraph app核心分层
+      UI[Activity / Fragment / Adapter\nMainActivity / ViewerActivity / ImageFragment]
+      MVP[Contract + Presenter\nMainContact / ViewerContact\nMainPresenter / ViewerPresenter]
+      DATA[Data\nMediaDataSource(MediaRepository)\nMediaCache]
+      MODEL[Model\nMedia 抽象 + Local/Samba/WebDav/AutoIndex]
+      DB[Database\nRequery + Server 实体]
+      DI[Dagger DI\nAppComponent + AppModule]
+      IMG[Glide 自定义加载\nMediaLoader + MediaDataFetcher]
+    end
+
+    A --> UI
+    A --> MVP
+    A --> DI
+    UI <--> MVP
+    MVP --> DATA
+    DATA --> MODEL
+    MVP --> DB
+    UI --> IMG
+    IMG --> MODEL
+    DI --> MVP
+    DI --> DATA
+    DI --> DB
+```
+
+---
+
+## 2) 主流程速查（从启动到看图）
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Main as MainActivity
+    participant MP as MainPresenter
+    participant Repo as MediaRepository
+    participant DB as Database
+    participant Viewer as ViewerActivity
+    participant VP as ViewerPresenter
+
+    App->>App: 创建 AppComponent 并注入全局依赖
+    Main->>MP: start()
+    MP->>Repo: register(Local/Samba/WebDav/AutoIndex)
+    MP->>Repo: addRoot(本地目录)
+    MP->>DB: getServers()
+    DB-->>MP: 已保存的服务器
+    MP->>Repo: addRoot(远程源)
+    MP->>Repo: roots()/loadDir()
+    MP-->>Main: replaceData(...)
+
+    Main->>MP: clickItem(...)
+    alt 点击图片
+        MP-->>Main: startViewer(...)
+        Main->>Viewer: 传递 uri/parent/position
+        Viewer->>VP: loadData(...)
+        VP->>Repo: loadDir(parent)
+        VP->>Repo: loadMediaList(parent)
+        VP-->>Viewer: replaceData(纯图片列表, 当前索引)
+    else 点击目录
+        MP->>Repo: loadDir(child)
+        MP-->>Main: replaceData(...)
+    end
+```
+
+---
+
+## 3) 多协议扩展速查（新增一种来源怎么做）
+
+```mermaid
+flowchart LR
+    I[实现 Media 接口\n例如 XxxMedia]
+    S[声明 scheme()\n如 xxx://]
+    U[实现 fromUri()/children()/getInputStream()/auth()]
+    R[在 MainPresenter.start() 中 register(new XxxMedia())]
+    D[可选: 在数据库中保存连接信息]
+
+    I --> S --> U --> R --> D
+```
+
+---
+
+## 4) 新人建议阅读顺序（30~60 分钟）
+
+1. `app/src/main/AndroidManifest.xml`：先看页面入口与 Application。  
+2. `activity/MainActivity.java` + `presenter/MainPresenter.java`：理解主列表和目录导航。  
+3. `data/MediaDataSource.java` + `data/MediaRepository.java`：理解统一数据抽象。  
+4. `model/Media.java` + `model/media/*Media.java`：理解多协议统一机制。  
+5. `activity/ViewerActivity.java` + `presenter/ViewerPresenter.java` + `fragment/ImageFragment.java`：理解全屏查看链路。  
+6. `di/*`：看依赖注入怎么把对象串起来。  
+7. `glide/*`：理解为什么 Glide 能直接加载 `Media`。  
+
+---
+
+## 5) 常见排查点（实战高频）
+
+- 看不到某个远程源：先查 `register()` 是否注册对应 scheme，再看 `addRoot()` 的 URI 格式。  
+- 能进目录但无缩略图：查 `MediaDataFetcher` 是否拿到 `InputStream`，以及该目录是否有可识别图片后缀。  
+- 查看器位置错乱：重点看 `ViewerPresenter` 里“文件列表索引”和“纯图片索引”的转换逻辑。  
+- 返回键行为不符合预期：看 `MainPresenter.loadParent()` 与 `MainActivity.onBackPressed()` 联动。  
+

--- a/docs/quick-reference.zh-CN.md
+++ b/docs/quick-reference.zh-CN.md
@@ -80,9 +80,9 @@ sequenceDiagram
 ```mermaid
 flowchart LR
     I[实现 Media 接口\n例如 XxxMedia]
-    S[声明 scheme()\n如 xxx://]
-    U[实现 fromUri()/children()/getInputStream()/auth()]
-    R[在 MainPresenter.start 中调用 register 新实现]
+    S[声明协议标识 例如 smb 或 dav]
+    U[实现必要方法 fromUri children getInputStream auth]
+    R[在 MainPresenter start 中注册新实现]
     D[可选: 在数据库中保存连接信息]
 
     I --> S --> U --> R --> D


### PR DESCRIPTION
### Motivation

- Provide a concise Chinese quick-reference to help new contributors understand the gallery app architecture and common workflows. 
- Make the new document discoverable by adding a link in the project's `README.md`.

### Description

- Add `docs/quick-reference.zh-CN.md` which includes architecture diagrams, startup/viewer flows, multi-protocol extension notes, recommended reading order, and troubleshooting tips. 
- Update `README.md` to add a `文档` section that links to `docs/quick-reference.zh-CN.md`. 
- The quick-reference uses `mermaid` diagrams and short paths/commands to enable fast orientation for newcomers.

### Testing

- No automated tests were added or run because this change only adds documentation files and a README link.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b018a82b888324a36747126ad31e7a)